### PR TITLE
Analysing code coverage reports

### DIFF
--- a/FaunaDB.xcodeproj/project.pbxproj
+++ b/FaunaDB.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		450077621DF08D7B0064C81B /* TestUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450077611DF08D7B0064C81B /* TestUtils.swift */; };
+		45F357401E02CD6C002A45B2 /* AtomicIntTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45F3573F1E02CD6C002A45B2 /* AtomicIntTests.swift */; };
 		OBJ_44 /* AtomicInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* AtomicInt.swift */; };
 		OBJ_45 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* Client.swift */; };
 		OBJ_46 /* Codec.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* Codec.swift */; };
@@ -46,6 +47,7 @@
 
 /* Begin PBXFileReference section */
 		450077611DF08D7B0064C81B /* TestUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUtils.swift; sourceTree = "<group>"; };
+		45F3573F1E02CD6C002A45B2 /* AtomicIntTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicIntTests.swift; sourceTree = "<group>"; };
 		OBJ_10 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
 		OBJ_11 /* Codec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Codec.swift; sourceTree = "<group>"; };
 		OBJ_12 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
@@ -104,6 +106,7 @@
 		OBJ_27 /* FaunaDBTests */ = {
 			isa = PBXGroup;
 			children = (
+				45F3573F1E02CD6C002A45B2 /* AtomicIntTests.swift */,
 				OBJ_28 /* ClientTests.swift */,
 				OBJ_29 /* DeserializationTests.swift */,
 				OBJ_30 /* ErrorsTests.swift */,
@@ -278,6 +281,7 @@
 			files = (
 				OBJ_67 /* ClientTests.swift in Sources */,
 				OBJ_68 /* DeserializationTests.swift in Sources */,
+				45F357401E02CD6C002A45B2 /* AtomicIntTests.swift in Sources */,
 				OBJ_69 /* ErrorsTests.swift in Sources */,
 				OBJ_71 /* FieldTests.swift in Sources */,
 				450077621DF08D7B0064C81B /* TestUtils.swift in Sources */,

--- a/Sources/FaunaDB/AtomicInt.swift
+++ b/Sources/FaunaDB/AtomicInt.swift
@@ -5,9 +5,9 @@ internal final class AtomicInt {
     private let lock: DispatchQueue
     private var current: Int
 
-    init(label: String) {
+    init(label: String, initial: Int = 0) {
         self.lock = DispatchQueue(label: label)
-        self.current = 0
+        self.current = initial
     }
 
     func incrementAndGet() -> Int {

--- a/Sources/FaunaDB/Errors.swift
+++ b/Sources/FaunaDB/Errors.swift
@@ -185,7 +185,7 @@ extension QueryError: Equatable {
         return left.position == right.position &&
             left.code == right.code &&
             left.description == right.description &&
-            left.failures == left.failures
+            left.failures == right.failures
     }
 }
 

--- a/Tests/FaunaDBTests/AtomicIntTests.swift
+++ b/Tests/FaunaDBTests/AtomicIntTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+
+@testable import FaunaDB
+
+class AtomicIntTests: XCTestCase {
+
+    func testIncrementAndGetg() {
+        let atomic = AtomicInt(label: "testing-atomic-integer")
+        XCTAssertEqual(atomic.incrementAndGet(), 1)
+        XCTAssertEqual(atomic.incrementAndGet(), 2)
+    }
+
+    func testOverflow() {
+        let atomic = AtomicInt(label: "testing-atomic-integer", initial: Int.max - 1)
+        XCTAssertEqual(atomic.incrementAndGet(), Int.max)
+        XCTAssertEqual(atomic.incrementAndGet(), 0)
+    }
+
+}

--- a/Tests/FaunaDBTests/ErrorsTests.swift
+++ b/Tests/FaunaDBTests/ErrorsTests.swift
@@ -43,7 +43,7 @@ class ErrorsTests: XCTestCase {
                         [
                             "field": ["data", "token"],
                             "code": "invalid token",
-                            "description": "Ivalid token"
+                            "description": "Invalid token"
                         ]
                     ]
                 ]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+    ignore:
+        - Tests/.*


### PR DESCRIPTION
- Ignoring tests folder
- Testing `AtomicInt` overflow
- Fix bug on equality operator for `ValidationFailure`

The rest of the missing branches are either places where the coverage instrumentation can't verify that the branch was called but I manually check that they are being executed, safe guards for unexpected errors, or string representations for data structures.